### PR TITLE
Ensure html_root_url is in sync with crate version number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uri"
-version = "0.1.0" # remember to update html_root_url
+version = "0.1.0"
 readme = "README.md"
 documentation = "https://docs.rs/uri"
 repository = "https://github.com/hyperium/uri"
@@ -19,3 +19,5 @@ keywords = ["uri"]
 [dependencies]
 bytes = "0.4"
 
+[dev-dependencies]
+version-sync = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@
 //! assert_eq!(uri.path(), "/install.html");
 //! ```
 
+#![doc(html_root_url = "https://docs.rs/uri/0.1.0")]
+
 extern crate bytes;
 
 mod byte_str;

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -1,0 +1,12 @@
+#[macro_use]
+extern crate version_sync;
+
+#[test]
+fn test_readme_deps() {
+    assert_markdown_deps_updated!("README.md");
+}
+
+#[test]
+fn test_html_root_url() {
+    assert_html_root_url_updated!("src/lib.rs");
+}


### PR DESCRIPTION
This uses my version-sync crate to ensure that the version number
mentioned in [the `html_root_url` attribute][1] is kept in sync with the
crate version number.

[1]: https://rust-lang-nursery.github.io/api-guidelines/documentation.html#crate-sets-html_root_url-attribute-c-html-root  

The version number mentioned in the TOML example in the README is also
checked by the test.